### PR TITLE
Implement role based access to models

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -95,7 +95,7 @@ Authorization: Bearer dev-token
 RxInferServer.is_dev_token_enabled
 RxInferServer.is_dev_token_disabled
 RxInferServer.is_dev_token
-``` 
+```
 
 # [Server Edition](@id server-edition-configuration)
 

--- a/models/coin-toss-v1/config.yaml
+++ b/models/coin-toss-v1/config.yaml
@@ -2,4 +2,5 @@
 name: CoinToss-v1
 description: A simple coin toss model
 author: Lazy Dynamics
-private: false
+roles:
+  - user

--- a/src/models/dispatcher.jl
+++ b/src/models/dispatcher.jl
@@ -97,18 +97,19 @@ function reload!(dispatcher::ModelsDispatcher)
 end
 
 """
-    get_models(dispatcher::ModelsDispatcher)
+    get_models(dispatcher::ModelsDispatcher; role = nothing)
 
 Get all non-private models from the given dispatcher.
 
 # Arguments
 - `dispatcher::ModelsDispatcher`: The dispatcher to get models from
+- `roles::Union{Vector{String}, Nothing}`: The roles to filter models by (optional)
 
 # Returns
 - A collection of all non-private loaded models
 """
 function get_models(dispatcher::ModelsDispatcher)
-    return filter(m -> !m.private, collect(values(dispatcher.models)))
+    return collect(values(dispatcher.models))
 end
 
 """

--- a/src/models/loaded_model.jl
+++ b/src/models/loaded_model.jl
@@ -8,7 +8,7 @@ Represents a loaded RxInfer probabilistic model with its metadata and implementa
 - `name::String`: Name of the model
 - `description::String`: Description of the model's purpose and functionality
 - `author::String`: Author or organization that created the model
-- `private::Bool`: Whether the model is private (not listed in API responses)
+- `roles::Vector{String}`: List of roles that can access the model
 - `config::Dict{String, Any}`: Configuration parameters for the model
 - `mod::Module`: Julia module containing the model's implementation
 """
@@ -17,7 +17,7 @@ Base.@kwdef struct LoadedModel
     name::String
     description::String
     author::String
-    private::Bool
+    roles::Vector{String}
     config::Dict{String, Any}
     mod::Module
 end
@@ -36,15 +36,6 @@ Load a model from the specified directory path.
 # Throws
 - `ErrorException`: If model.jl or config.yaml is missing, or if required config fields are missing
 
-# Implementation Notes
-The model directory must contain:
-1. `model.jl`: Julia code implementing the model
-2. `config.yaml`: Configuration file with required fields:
-   - `name`: Model name
-   - `description`: Model description
-   - `author`: Model author
-   - `private`: Boolean indicating if model is private
-
 The model code is loaded into a separate module to isolate its namespace.
 """
 function LoadedModel(path::String)::LoadedModel
@@ -62,20 +53,14 @@ function LoadedModel(path::String)::LoadedModel
     name = config["name"]
     description = config["description"]
     author = config["author"]
-    private = config["private"]
+    roles = config["roles"]
 
     @debug "Including model's code from `$potential_model_file`"
     mod = Module(Symbol(:LoadedModel, name))
     Base.include(mod, potential_model_file)
 
-    @debug "Model `$(name)` has been loaded from `$path`" name description author private
+    @debug "Model `$(name)` has been loaded from `$path`" name description author roles
     return LoadedModel(
-        path = path,
-        name = name,
-        description = description,
-        author = author,
-        private = private,
-        config = config,
-        mod = mod
+        path = path, name = name, description = description, author = author, roles = roles, config = config, mod = mod
     )
 end

--- a/src/tags/Models.jl
+++ b/src/tags/Models.jl
@@ -3,8 +3,15 @@ function get_models(req::HTTP.Request)::HTTP.Response
     # Filter out private models
     models = Models.get_models()
 
+    # Filter models by role if provided
+    roles = current_roles()
+
+    filtered_models = filter(models) do model
+        return any(r -> r in roles, model.roles)
+    end
+
     # Create a list of lightweight model info
-    model_list = map(models) do model
+    model_list = map(filtered_models) do model
         return RxInferServerOpenAPI.LightweightModelInfo(name = model.name, description = model.description)
     end
 
@@ -15,6 +22,15 @@ function get_model_info(req::HTTP.Request, model_name::String)::HTTP.Response
     model = Models.get_model(model_name)
 
     if isnothing(model)
+        return HTTP.Response(
+            404,
+            RxInferServerOpenAPI.ErrorResponse(error = "Not Found", message = "The requested model could not be found")
+        )
+    end
+
+    roles = current_roles()
+
+    if !any(r -> r in roles, model.roles)
         return HTTP.Response(
             404,
             RxInferServerOpenAPI.ErrorResponse(error = "Not Found", message = "The requested model could not be found")

--- a/test/tags/Models_tests.jl
+++ b/test/tags/Models_tests.jl
@@ -10,6 +10,29 @@
     @test any(m -> m.name === "CoinToss-v1", response.models)
 end
 
+@testitem "200 on /models endpoint but arbitrary role should return empty list" setup = [TestUtils] begin
+    TestUtils.with_temporary_token(role = "arbitrary") do
+        client = TestUtils.TestClient()
+        models_api = TestUtils.RxInferClientOpenAPI.ModelsApi(client)
+        response, info = TestUtils.RxInferClientOpenAPI.get_models(models_api)
+        @test info.status == 200
+        @test isempty(response.models)
+    end
+end
+
+@testitem "200 on /models endpoint with mixed roles should return non-empty list" setup = [TestUtils] begin
+    for role in ["arbitrary,user", "user,arbitrary"]
+        TestUtils.with_temporary_token(role = role) do
+            client = TestUtils.TestClient()
+            models_api = TestUtils.RxInferClientOpenAPI.ModelsApi(client)
+            response, info = TestUtils.RxInferClientOpenAPI.get_models(models_api)
+            @test info.status == 200
+            @test !isempty(response.models)
+            @test any(m -> m.name === "CoinToss-v1", response.models)
+        end
+    end
+end
+
 @testitem "401 on /models endpoint without authorization" setup = [TestUtils] begin
     client = TestUtils.TestClient(authorized = false)
     models_api = TestUtils.RxInferClientOpenAPI.ModelsApi(client)
@@ -44,6 +67,29 @@ end
     @test response.config["name"] == "CoinToss-v1"
     @test response.config["description"] == "A simple coin toss model"
     @test response.config["author"] == "Lazy Dynamics"
+end
+
+@testitem "404 on model info endpoint if user's role does not have access" setup = [TestUtils] begin
+    TestUtils.with_temporary_token(role = "arbitrary") do
+        client = TestUtils.TestClient()
+        models_api = TestUtils.RxInferClientOpenAPI.ModelsApi(client)
+        response, info = TestUtils.RxInferClientOpenAPI.get_model_info(models_api, "CoinToss-v1")
+
+        @test info.status == 404
+        @test response.error == "Not Found"
+        @test response.message == "The requested model could not be found"
+    end
+end
+
+@testitem "200 on model info endpoint with mixed roles" setup = [TestUtils] begin
+    for role in ["arbitrary,user", "user,arbitrary"]
+        TestUtils.with_temporary_token(role = role) do
+            client = TestUtils.TestClient()
+            models_api = TestUtils.RxInferClientOpenAPI.ModelsApi(client)
+            response, info = TestUtils.RxInferClientOpenAPI.get_model_info(models_api, "CoinToss-v1")
+            @test info.status == 200
+        end
+    end
 end
 
 @testitem "401 on model info endpoint without authorization" setup = [TestUtils] begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,20 +2,107 @@
     using Test, RxInferServer
     using Base.ScopedValues
 
+    import Mongoc
     import RxInferClientOpenAPI
     import RxInferClientOpenAPI.OpenAPI.Clients: Client, set_header
-    import RxInferClientOpenAPI: ServerApi, AuthenticationApi
-
-    export TestClient
-    export ServerApi, AuthenticationApi
+    import RxInferClientOpenAPI: ServerApi, AuthenticationApi, ModelsApi
 
     const TEST_SERVER_URL = "http://localhost:8000$(RxInferServer.API_PATH_PREFIX)"
+    const TEST_TOKEN = ScopedValue{String}(RxInferServer.RXINFER_SERVER_DEV_TOKEN())
 
-    function TestClient(; authorized = true, token = RxInferServer.RXINFER_SERVER_DEV_TOKEN())
+    current_test_token() = TEST_TOKEN[]
+
+    function TestClient(; authorized = true, token = current_test_token())
         _client = Client(TEST_SERVER_URL)
-        if authorized
-            set_header(_client, "Authorization", "Bearer $(token)")
+        _token = @something token RxInferServer.RXINFER_SERVER_DEV_TOKEN()
+
+        if authorized && !isnothing(_token)
+            set_header(_client, "Authorization", "Bearer $(_token)")
         end
+
+        if authorized && isnothing(_token)
+            error(
+                "Cannot be authorized if no token is provided. Use `RXINFER_SERVER_DEV_TOKEN` environment variable to set a default token for testing purposes."
+            )
+        end
+
         return _client
+    end
+
+    function with_temporary_token(f::Function; role::String = "user")
+        _client = TestClient(authorized = false)
+
+        auth = RxInferClientOpenAPI.AuthenticationApi(_client)
+        response, info = RxInferClientOpenAPI.generate_token(auth)
+
+        if info.status != 200
+            error("Failed to generate a temporary token for role `$role`")
+        end
+
+        token = string(response.token)
+
+        # Update the token with the specified role in the database
+        RxInferServer.Database.with_connection() do
+            collection = RxInferServer.Database.collection("tokens")
+            query = Mongoc.BSON("token" => token)
+            update = Mongoc.BSON("\$set" => Mongoc.BSON("role" => role))
+            result = Mongoc.update_one(collection, query, update)
+
+            if result["modifiedCount"] != 1
+                error("Failed to update token with role `$role`")
+            end
+        end
+
+        try
+            with(TEST_TOKEN => token) do
+                f()
+            end
+        finally
+            # Delete the token from the database
+            RxInferServer.Database.with_connection() do
+                collection = RxInferServer.Database.collection("tokens")
+                query = Mongoc.BSON("token" => token)
+                result = Mongoc.delete_one(collection, query)
+
+                if result["deletedCount"] != 1
+                    error("Failed to delete token from the database")
+                end
+            end
+        end
+    end
+end
+
+@testitem "TestClient should be able to generate a token for a role" setup = [TestUtils] begin
+    client = TestUtils.TestClient()
+    @test client.headers["Authorization"] == "Bearer $(RxInferServer.RXINFER_SERVER_DEV_TOKEN())"
+end
+
+@testitem "TestClient should be able to generate a temporary token with an arbitrary role" setup = [TestUtils] begin
+    using Mongoc
+
+    created_token = Ref{String}("")
+    default_token = TestUtils.current_test_token()
+    TestUtils.with_temporary_token(role = "arbitrary,arbitrary2") do
+        client = TestUtils.TestClient()
+        temporary_token = TestUtils.current_test_token()
+        @test temporary_token != default_token
+        @test client.headers["Authorization"] == "Bearer $(temporary_token)"
+        created_token[] = temporary_token
+
+        # Check the role of the token in the database 
+        RxInferServer.Database.with_connection() do
+            collection = RxInferServer.Database.collection("tokens")
+            query = Mongoc.BSON("token" => created_token[])
+            result = Mongoc.find_one(collection, query)
+            @test result["role"] == "arbitrary,arbitrary2"
+        end
+    end
+
+    # Check that the token was deleted from the database
+    RxInferServer.Database.with_connection() do
+        collection = RxInferServer.Database.collection("tokens")
+        query = Mongoc.BSON("token" => created_token[])
+        result = Mongoc.find_one(collection, query)
+        @test isnothing(result)
     end
 end


### PR DESCRIPTION
This token adds "roles" to token to filter access to different models. Default tokens are created with only "user" role. Roles can only be changed in the database manually for now