### PR TITLE
Fix make serve-docs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ docs-build: ## Build the documentation
 	julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
 	julia --startup-file=no --project=docs docs/make.jl
 
-docs-serve: ## Serve documentation locally for preview in browser (requires LiveServer.jl installed globally)
+docs-serve: ## Serve documentation locally for preview in browser (requires LiveServer.jl installed globally, ignores changes to auto-generatedopenapi documentation)
 	julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-	julia --startup-file=no --project=docs -e 'using LiveServer; servedocs()'
+	julia --startup-file=no --project=docs -e 'using LiveServer; servedocs(skip_dir=joinpath("docs", "src", "openapi"))'
 
 docs-clean: ## Clean the documentation build directory
 	rm -rf docs/build/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ docs-build: ## Build the documentation
 
 docs-serve: ## Serve documentation locally for preview in browser (requires LiveServer.jl installed globally, ignores changes to auto-generatedopenapi documentation)
 	julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-	julia --startup-file=no --project=docs -e 'using LiveServer; servedocs(skip_dir=joinpath("docs", "src", "openapi"))'
+	julia --startup-file=no --project=docs -e 'using LiveServer; servedocs(skip_dirs=[joinpath("docs", "src", "openapi")])'
 
 docs-clean: ## Clean the documentation build directory
 	rm -rf docs/build/

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ docs-build: ## Build the documentation
 	julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
 	julia --startup-file=no --project=docs docs/make.jl
 
-docs-serve: ## Serve documentation locally for preview in browser (requires LiveServer.jl installed globally, ignores changes to auto-generatedopenapi documentation)
+docs-serve: ## Serve documentation locally for preview in browser (requires LiveServer.jl installed globally, ignores changes to auto-generated openapi documentation)
 	julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
 	julia --startup-file=no --project=docs -e 'using LiveServer; servedocs(skip_dirs=[joinpath("docs", "src", "openapi")])'
 


### PR DESCRIPTION
This PR fixes #32 

The `make.jl` script was triggering the documentation re-build because it was constantly copying files from the `openapi` autogenerated docs, which triggered docs rebuild which triggered copying files which triggered rebuild and so on...

This PR adds the `openapi` docs to the `skip_dirs` option.