### PR TITLE
Add compilation trace to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Run tests
         env:
           RXINFER_SERVER_ENABLE_DEBUG_LOGGING: ${{ github.event_name == 'workflow_dispatch' }}
+          TRACE_COMPILE_PATH: ${{ github.workspace }}/server-compilation-trace.jl
         run: |
           # Start the docker compose environment
           make docker-start
@@ -46,11 +47,19 @@ jobs:
           # Precompile deps before running the server and tests 
           make deps
           
-          # Start the Julia server in the background
+          # Start the Julia server in the background with trace compilation
           make serve &
           
           # Run tests (runtests.jl has built-in server availability check)
           make test
+      
+      - name: Upload trace compilation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-compilation-trace
+          path: server-compilation-trace.jl
+          retention-days: 30
+          if-no-files-found: warn
 
   docs:
     name: Documentation

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ test: deps ## Run project tests
 	julia --project -e 'using Pkg; Pkg.test()'
 
 serve: deps ## Run the server (with .env.development)
-	RXINFER_SERVER_ENV=development julia --project -e 'using RxInferServer; RxInferServer.serve()'
+	$(eval TRACE_COMPILE_PATH ?=)
+	$(eval TRACE_COMPILE_FLAG := $(if $(TRACE_COMPILE_PATH),--trace-compile=$(TRACE_COMPILE_PATH),))
+	RXINFER_SERVER_ENV=development julia --project $(TRACE_COMPILE_FLAG) -e 'using RxInferServer; RxInferServer.serve()'
 
 docker: docker-start ## Starts the docker compose environment
 


### PR DESCRIPTION
This PR modifies CI to keep track of compilation statements during testing on CI, will make it easier to compile the app to the binary later on