### PR TITLE
This PR moves the documentation to server.rxinfer.com

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -202,7 +202,7 @@ makedocs(;
     sitename = "RxInferServer",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", nothing) == "true",
-        canonical = "https://api.rxinfer.com",
+        canonical = "https://server.rxinfer.com",
         edit_link = "main",
         assets = [],
         description = "A RESTful HTTP server implementation for RxInfer.jl, a reactive message passing inference engine for probabilistic models.",
@@ -225,5 +225,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo = "github.com/lazydynamics/RxInferServer.jl", devbranch = "main", forcepush = true, cname = "api.rxinfer.com"
+    repo = "github.com/lazydynamics/RxInferServer.jl", devbranch = "main", forcepush = true, cname = "server.rxinfer.com"
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,8 +17,8 @@ RxInferServer provides a REST API server for [RxInfer.jl](https://github.com/bia
 
 The RxInferServer API is documented using the OpenAPI specification. You can explore the API in the following ways:
 
-1. Interact with the stable version of the API using the [Swagger UI](https://petstore.swagger.io/?url=https://api.rxinfer.com/stable/openapi/spec.yaml)
-2. Interact with the latest version of the API using the [Swagger UI](https://petstore.swagger.io/?url=https://api.rxinfer.com/dev/openapi/spec.yaml)
+1. Interact with the stable version of the API using the [Swagger UI](https://petstore.swagger.io/?url=https://server.rxinfer.com/stable/openapi/spec.yaml)
+2. Interact with the latest version of the API using the [Swagger UI](https://petstore.swagger.io/?url=https://server.rxinfer.com/dev/openapi/spec.yaml)
 
 The Swagger UI provides an interactive interface to explore the API endpoints, make test requests, and view response formats. It's a helpful tool for developers integrating with the RxInferServer API.
 

--- a/src/RxInferServer.jl
+++ b/src/RxInferServer.jl
@@ -180,7 +180,7 @@ RXINFER_SERVER_LISTEN_KEYBOARD() =
     serve() -> HTTP.Server
 
 Start the RxInfer API server with the configured settings.
-Official documentation is available at https://api.rxinfer.com/
+Official documentation is available at https://server.rxinfer.com/
 
 # Description
 Initializes and starts an HTTP server that exposes RxInfer functionality through a REST API.
@@ -233,7 +233,7 @@ function serve()
                 Welcome to RxInfer Server! (version: $(pkgversion(RxInferServer)))
                 Listening on $(server.ip):$(server.port)
                 
-                API Documentation: https://api.rxinfer.com
+                API Documentation: https://server.rxinfer.com
                 RxInfer Documentation: https://docs.rxinfer.com
 
                 .env files: $(join(dotenv_loaded, ", "))


### PR DESCRIPTION
api.rxinfer.com will be used for the actual API endpoints